### PR TITLE
More windows compatible compiling

### DIFF
--- a/meflib/meflib.c
+++ b/meflib/meflib.c
@@ -6616,8 +6616,11 @@ void 	RED_decode(RED_PROCESSING_STRUCT *rps)
 	} else if (block_header->flags & RED_LEVEL_2_ENCRYPTION_MASK) {
 		rps->directives.encryption_level = LEVEL_2_ENCRYPTION;
 		key = rps->password_data->level_2_encryption_key;
-	} else
+	} else {
 		rps->directives.encryption_level = NO_ENCRYPTION;
+		key = NULL;
+	}
+	
 	if (rps->directives.encryption_level > NO_ENCRYPTION) {
 		if (rps->password_data->access_level >= rps->directives.encryption_level) {
 			AES_decrypt(block_header->statistics, block_header->statistics, NULL, key);

--- a/meflib/meflib.c
+++ b/meflib/meflib.c
@@ -3727,10 +3727,13 @@ si4	fps_open(FILE_PROCESSING_STRUCT *fps, const si1 *function, si4 line, ui4 beh
 			exit(1);
 	}
 	
-	// get file descriptor
-	fps->fd = fileno(fps->fp);
-	
-	#ifndef _WIN32
+	#ifdef _WIN32
+		// get file descriptor
+		fps->fd = _fileno(fps->fp);
+    #else
+		// get file descriptor
+		fps->fd = fileno(fps->fp);
+		
 		// lock
 		if (fps->directives.lock_mode != FPS_NO_LOCK_MODE) {
 			lock_type = FPS_NO_LOCK_TYPE;


### PR DESCRIPTION
Hi Jan and Dan,

I was using and compiling meflib in Visual Studio directly (so not compiling via matlab this time), and Visual studio comes up with two errors before you can compile. I though I would share the fixes, so others don't have to handle these errors before being able to use the library.

The first error that I got came from the use of `fileno` (on line 3731). This has been deprecated for windows (https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/posix-fileno?view=vs-2019). I understand for UNIX this is the standard so I changed the precompiler to differentiate: `fileno` for unix, `_fileno` for windows

The second error that the compiler gives is `potentially uninitialized local pointer variable 'key' used` (on line 6620). If I follow the logic of the program, it currently should not reach that line if indeed `key` is not set; but the compiler gives an error because hypothetically encryption_level could get a value higher than 2 (`LEVEL_2_ENCRYPTION`) which would cause it to indeed use `key` as a uninitialized local pointer. I fixed it by added a NULL initialization for `key` to the existing `else` that precedes it.

After these fixes, it will compile in Visual Studio. Hope this helps others!