### PR TITLE
Incorrect latest_end_time while data is being streamed/written

### DIFF
--- a/meflib/meflib.c
+++ b/meflib/meflib.c
@@ -5398,6 +5398,8 @@ CHANNEL	*read_MEF_channel(CHANNEL *channel, si1 *chan_path, si4 channel_type, si
 				channel->earliest_start_time = seg->metadata_fps->universal_header->start_time;
 			if (ABS(seg->metadata_fps->universal_header->end_time) > ABS(channel->latest_end_time))
 				channel->latest_end_time = seg->metadata_fps->universal_header->end_time;
+			if (seg->time_series_data_fps != NULL && (ABS(seg->time_series_data_fps->universal_header->end_time) < ABS(channel->latest_end_time)))
+				channel->latest_end_time = seg->time_series_data_fps->universal_header->end_time;
 			if (strcmp(channel->anonymized_name, seg->metadata_fps->universal_header->anonymized_name))
 				bzero(channel->anonymized_name, UNIVERSAL_HEADER_ANONYMIZED_NAME_BYTES);
 			if (seg->record_data_fps != NULL) {
@@ -5528,6 +5530,8 @@ CHANNEL	*read_MEF_channel(CHANNEL *channel, si1 *chan_path, si4 channel_type, si
 				channel->earliest_start_time = seg->metadata_fps->universal_header->start_time;
 			if (ABS(seg->metadata_fps->universal_header->end_time) > ABS(channel->latest_end_time))
 				channel->latest_end_time = seg->metadata_fps->universal_header->end_time;
+			if (seg->time_series_data_fps != NULL && (ABS(seg->time_series_data_fps->universal_header->end_time) < ABS(channel->latest_end_time)))
+				channel->latest_end_time = seg->time_series_data_fps->universal_header->end_time;
 			if (strcmp(channel->anonymized_name, seg->metadata_fps->universal_header->anonymized_name))
 				bzero(channel->anonymized_name, UNIVERSAL_HEADER_ANONYMIZED_NAME_BYTES);
 			if (seg->record_data_fps != NULL) {

--- a/meflib/meflib.c
+++ b/meflib/meflib.c
@@ -5400,6 +5400,8 @@ CHANNEL	*read_MEF_channel(CHANNEL *channel, si1 *chan_path, si4 channel_type, si
 				channel->latest_end_time = seg->metadata_fps->universal_header->end_time;
 			if (seg->time_series_data_fps != NULL && (ABS(seg->time_series_data_fps->universal_header->end_time) < ABS(channel->latest_end_time)))
 				channel->latest_end_time = seg->time_series_data_fps->universal_header->end_time;
+			if (seg->time_series_indices_fps != NULL && (ABS(seg->time_series_indices_fps->universal_header->end_time) < ABS(channel->latest_end_time)))
+				channel->latest_end_time = seg->time_series_indices_fps->universal_header->end_time;
 			if (strcmp(channel->anonymized_name, seg->metadata_fps->universal_header->anonymized_name))
 				bzero(channel->anonymized_name, UNIVERSAL_HEADER_ANONYMIZED_NAME_BYTES);
 			if (seg->record_data_fps != NULL) {
@@ -5532,6 +5534,8 @@ CHANNEL	*read_MEF_channel(CHANNEL *channel, si1 *chan_path, si4 channel_type, si
 				channel->latest_end_time = seg->metadata_fps->universal_header->end_time;
 			if (seg->time_series_data_fps != NULL && (ABS(seg->time_series_data_fps->universal_header->end_time) < ABS(channel->latest_end_time)))
 				channel->latest_end_time = seg->time_series_data_fps->universal_header->end_time;
+			if (seg->time_series_indices_fps != NULL && (ABS(seg->time_series_indices_fps->universal_header->end_time) < ABS(channel->latest_end_time)))
+				channel->latest_end_time = seg->time_series_indices_fps->universal_header->end_time;
 			if (strcmp(channel->anonymized_name, seg->metadata_fps->universal_header->anonymized_name))
 				bzero(channel->anonymized_name, UNIVERSAL_HEADER_ANONYMIZED_NAME_BYTES);
 			if (seg->record_data_fps != NULL) {

--- a/meflib/meflib.c
+++ b/meflib/meflib.c
@@ -5378,25 +5378,21 @@ CHANNEL	*read_MEF_channel(CHANNEL *channel, si1 *chan_path, si4 channel_type, si
 			smd3 = seg->metadata_fps->metadata.section_3;
 			cmd3 = channel->metadata.section_3;
 			if (i == 0) {
-                                memcpy(cmd1, smd1, METADATA_SECTION_1_BYTES);
-                                memcpy(ctmd, stmd, METADATA_SECTION_2_BYTES);
-                                memcpy(cmd3, smd3, METADATA_SECTION_3_BYTES);
-                                if (ABS(channel->earliest_start_time) > ABS(seg->metadata_fps->universal_header->start_time))
-					channel->earliest_start_time = seg->metadata_fps->universal_header->start_time;
-                                if (ABS(channel->latest_end_time) < ABS(seg->metadata_fps->universal_header->end_time))
-					channel->latest_end_time = seg->metadata_fps->universal_header->end_time;
-                                if (seg->record_data_fps != NULL) {
-                                	if (channel->maximum_number_of_records < seg->record_data_fps->universal_header->number_of_entries)
+				memcpy(cmd1, smd1, METADATA_SECTION_1_BYTES);
+				memcpy(ctmd, stmd, METADATA_SECTION_2_BYTES);
+				memcpy(cmd3, smd3, METADATA_SECTION_3_BYTES);
+				if (seg->record_data_fps != NULL) {
+					if (channel->maximum_number_of_records < seg->record_data_fps->universal_header->number_of_entries)
 						channel->maximum_number_of_records = seg->record_data_fps->universal_header->number_of_entries;
-                                        if (channel->maximum_record_bytes < seg->record_data_fps->universal_header->maximum_entry_size)
+					if (channel->maximum_record_bytes < seg->record_data_fps->universal_header->maximum_entry_size)
 						channel->maximum_record_bytes = seg->record_data_fps->universal_header->maximum_entry_size;
-                                }
+				}
 				if (strlen(channel->anonymized_name) == 0)
 					MEF_strncpy(channel->anonymized_name, seg->metadata_fps->universal_header->anonymized_name, UNIVERSAL_HEADER_ANONYMIZED_NAME_BYTES);
 				else if (strcmp(channel->anonymized_name, seg->metadata_fps->universal_header->anonymized_name))
 					bzero(channel->anonymized_name, UNIVERSAL_HEADER_ANONYMIZED_NAME_BYTES);
-                                continue;
-                        }
+				continue;
+			}
 			// universal header
 			if (ABS(seg->metadata_fps->universal_header->start_time) < ABS(channel->earliest_start_time))
 				channel->earliest_start_time = seg->metadata_fps->universal_header->start_time;
@@ -5515,10 +5511,6 @@ CHANNEL	*read_MEF_channel(CHANNEL *channel, si1 *chan_path, si4 channel_type, si
 				memcpy(cmd1, smd1, METADATA_SECTION_1_BYTES);
 				memcpy(cvmd, svmd, METADATA_SECTION_2_BYTES);
 				memcpy(cmd3, smd3, METADATA_SECTION_3_BYTES);
-				if (ABS(channel->earliest_start_time) > ABS(seg->metadata_fps->universal_header->start_time))
-					channel->earliest_start_time = seg->metadata_fps->universal_header->start_time;
-				if (ABS(channel->latest_end_time) < ABS(seg->metadata_fps->universal_header->end_time))
-					channel->latest_end_time = seg->metadata_fps->universal_header->end_time;
 				if (seg->record_data_fps != NULL) {
 					if (channel->maximum_number_of_records < seg->record_data_fps->universal_header->number_of_entries)
 						channel->maximum_number_of_records = seg->record_data_fps->universal_header->number_of_entries;
@@ -6074,10 +6066,6 @@ SESSION	*read_MEF_session(SESSION *session, si1 *sess_path, si1 *password, PASSW
 			memcpy(smd1, cmd1, METADATA_SECTION_1_BYTES);
 			memcpy(stmd, ctmd, METADATA_SECTION_2_BYTES);
 			memcpy(smd3, cmd3, METADATA_SECTION_3_BYTES);
-			if (ABS(session->earliest_start_time) > ABS(chan->earliest_start_time))
-				session->earliest_start_time = chan->earliest_start_time;
-			if (ABS(session->latest_end_time) < ABS(chan->latest_end_time))
-				session->latest_end_time = chan->latest_end_time;
 			if (chan->record_data_fps != NULL) {
 				if (session->maximum_number_of_records < chan->maximum_number_of_records)
 					session->maximum_number_of_records = chan->maximum_number_of_records;
@@ -6213,10 +6201,6 @@ SESSION	*read_MEF_session(SESSION *session, si1 *sess_path, si1 *password, PASSW
 			memcpy(smd1, cmd1, METADATA_SECTION_1_BYTES);
 			memcpy(svmd, cvmd, METADATA_SECTION_2_BYTES);
 			memcpy(smd3, cmd3, METADATA_SECTION_3_BYTES);
-			if (ABS(session->earliest_start_time) > ABS(chan->earliest_start_time))
-				session->earliest_start_time = chan->earliest_start_time;
-			if (ABS(session->latest_end_time) < ABS(chan->latest_end_time))
-				session->latest_end_time = chan->latest_end_time;
 			if (chan->record_data_fps != NULL) {
 				if (session->maximum_number_of_records < chan->maximum_number_of_records)
 					session->maximum_number_of_records = chan->maximum_number_of_records;

--- a/meflib/meflib.c
+++ b/meflib/meflib.c
@@ -5624,10 +5624,6 @@ CHANNEL	*read_MEF_channel(CHANNEL *channel, si1 *chan_path, si4 channel_type, si
 				channel->maximum_number_of_records = channel->record_data_fps->universal_header->number_of_entries;
 			if (channel->maximum_record_bytes < channel->record_data_fps->universal_header->maximum_entry_size)
 				channel->maximum_record_bytes = channel->record_data_fps->universal_header->maximum_entry_size;
-			if (ABS(channel->record_data_fps->universal_header->start_time) < ABS(channel->earliest_start_time))
-				channel->earliest_start_time = channel->record_data_fps->universal_header->start_time;
-			if (ABS(channel->record_data_fps->universal_header->end_time) > ABS(channel->latest_end_time))
-				channel->latest_end_time = channel->record_data_fps->universal_header->end_time;
 			MEF_strncpy(channel->anonymized_name, channel->record_data_fps->universal_header->anonymized_name, UNIVERSAL_HEADER_ANONYMIZED_NAME_BYTES);
 		}
 

--- a/meflib/meflib.c
+++ b/meflib/meflib.c
@@ -5532,10 +5532,8 @@ CHANNEL	*read_MEF_channel(CHANNEL *channel, si1 *chan_path, si4 channel_type, si
 				channel->earliest_start_time = seg->metadata_fps->universal_header->start_time;
 			if (ABS(seg->metadata_fps->universal_header->end_time) > ABS(channel->latest_end_time))
 				channel->latest_end_time = seg->metadata_fps->universal_header->end_time;
-			if (seg->time_series_data_fps != NULL && (ABS(seg->time_series_data_fps->universal_header->end_time) < ABS(channel->latest_end_time)))
-				channel->latest_end_time = seg->time_series_data_fps->universal_header->end_time;
-			if (seg->time_series_indices_fps != NULL && (ABS(seg->time_series_indices_fps->universal_header->end_time) < ABS(channel->latest_end_time)))
-				channel->latest_end_time = seg->time_series_indices_fps->universal_header->end_time;
+			if (seg->video_indices_fps != NULL && (ABS(seg->video_indices_fps->universal_header->end_time) < ABS(channel->latest_end_time)))
+				channel->latest_end_time = seg->video_indices_fps->universal_header->end_time;
 			if (strcmp(channel->anonymized_name, seg->metadata_fps->universal_header->anonymized_name))
 				bzero(channel->anonymized_name, UNIVERSAL_HEADER_ANONYMIZED_NAME_BYTES);
 			if (seg->record_data_fps != NULL) {


### PR DESCRIPTION
Hey Dan, to summarize what we discussed:

While reading MEF3 while data is being streamed/written, then
`metadata_fps->universal_header->end_time`
`time_series_data_fps->universal_header->end_time`
`time_series_indices_fps->universal_header->end_time` 
might differ, due to a delay in writing/flushing.

Meflib uses `metadata_fps->universal_header->end_time` to determine the `latest_end_time` in its session and channel struct. However, if meflib is integrated and `latest_end_time` is used, then the data might actually not be be available.

The improvement this PR offers is that, when either the _data or _indices are available, then the latest_end_time will be corrected to the most conservative (earliest) value.

This also is applied to video channels.

