### PR TITLE
Linux GCC compilation fails because of undefined struct tm

### DIFF
--- a/meflib/meflib.h
+++ b/meflib/meflib.h
@@ -67,6 +67,7 @@
 	#include <unistd.h>
 	#include <stdio.h>
 	#include <string.h>
+	#include <time.h>
 	#include <sys/time.h>
 	#include <math.h>
 	#include <float.h>


### PR DESCRIPTION
Hi Dan,

I was trying to compile meflib/matmef in Linux (Debian 10; GCC 8.3.0) and encountered the following error:
```
./meflib/meflib.c: In function ‘generate_recording_time_offset’:
./meflib/meflib.c:4277:12: error: storage size of ‘time_info’ isn’t known
  struct tm time_info;
            ^~~~~~~~~
```
Pretty cryptic message from GCC, but it just means that in that line the struct `tm` is undefined. 
In meflib.h, the precompiler directives makes sure that for a non-windows compile `<sys/time.h>` is included, this is enough for Mac but not for Linux. Linux also requires `<time.h>` to be included to have the `tm` struct defined.

The solution is to simply include  `<time.h>` in the non-windows precompiler directives. Mac/Clang doesn't mind the extra include, I've tried compiling on Mac and no problem. Could you accept/merge this pull request so that people can use matmef in Linux as well?

Cheers,
Max
