### PR TITLE
Update the reference_description variable to use the correct precompiler constant

### DIFF
--- a/meflib/meflib.h
+++ b/meflib/meflib.h
@@ -652,7 +652,7 @@ typedef struct {
         si1			session_description[METADATA_SESSION_DESCRIPTION_BYTES]; // utf8[511];
         si8			recording_duration;
         // type-specific fields
-	si1			reference_description[METADATA_CHANNEL_DESCRIPTION_BYTES]; // utf8[511];
+	si1			reference_description[TIME_SERIES_METADATA_REFERENCE_DESCRIPTION_BYTES]; // utf8[511];
 	si8			acquisition_channel_number;
         sf8			sampling_frequency;
         sf8			low_frequency_filter_setting;


### PR DESCRIPTION
Hey Dan,

Small correction on something I encountered by chance. I think the `reference_description` variable in the time-series section 2 struct `TIME_SERIES_METADATA_SECTION_2` is defined with the "wrong" pre-compiler constant.

The constant `TIME_SERIES_METADATA_REFERENCE_DESCRIPTION_BYTES` has always existed, but was never used. It will make no difference in functionality as it is the same as `METADATA_CHANNEL_DESCRIPTION_BYTES`, but pretty sure this is how it was meant.

Best,
Max