### PR TITLE
Fix unexpected shift on time 0 and no_entry checks

### DIFF
--- a/meflib/meflib.c
+++ b/meflib/meflib.c
@@ -7615,7 +7615,7 @@ inline void	remove_recording_time_offset(si8 *time)
         if (*time == UUTC_NO_ENTRY)
                 return;
 	
-	if (*time > 0)  // positive times indicate recording time offset not applied, 0 - unlikely any records started at 1970.
+	if (*time >= 0)  // 0 and positive times indicate recording time offset not applied
 		return;
 	
 	// remove recording time offset & make positive to indicate removal

--- a/meflib/meflib.c
+++ b/meflib/meflib.c
@@ -743,15 +743,17 @@ FILE_PROCESSING_STRUCT	*allocate_file_processing_struct(si8 raw_data_bytes, ui4 
 
 inline void	apply_recording_time_offset(si8 *time)
 {
-        if (*time == UUTC_NO_ENTRY)
-                return;
+    if (*time == UUTC_NO_ENTRY)
+        return;
         
 	if (*time < 0)  // negative times indicate recording time offset already applied
 		return;
 	
-	// apply recording time offset & make negative to indicate application
-	*time = -(*time - MEF_globals->recording_time_offset);
-	
+	// apply recording time offset (on valid offset entry) and make negative to indicate application
+	if (MEF_globals->recording_time_offset == METADATA_RECORDING_TIME_OFFSET_NO_ENTRY)
+		*time = -(*time);
+	else
+		*time = -(*time - MEF_globals->recording_time_offset);
         
 	return;
 }
@@ -7612,15 +7614,17 @@ void	remove_line_noise_adaptive(si4 *data, si8 n_samps, sf8 sampling_frequency, 
 
 inline void	remove_recording_time_offset(si8 *time)
 {
-        if (*time == UUTC_NO_ENTRY)
-                return;
+    if (*time == UUTC_NO_ENTRY)
+        return;
 	
 	if (*time >= 0)  // 0 and positive times indicate recording time offset not applied
 		return;
 	
-	// remove recording time offset & make positive to indicate removal
-	*time = (-*time) + MEF_globals->recording_time_offset;
-	
+	// remove recording time offset (on valid offset entry) and make positive to indicate removal
+	if (MEF_globals->recording_time_offset == METADATA_RECORDING_TIME_OFFSET_NO_ENTRY)
+		*time = -(*time);
+	else
+		*time = (-*time) + MEF_globals->recording_time_offset;
 	
 	return;
 }

--- a/meflib/meflib.c
+++ b/meflib/meflib.c
@@ -743,8 +743,8 @@ FILE_PROCESSING_STRUCT	*allocate_file_processing_struct(si8 raw_data_bytes, ui4 
 
 inline void	apply_recording_time_offset(si8 *time)
 {
-    if (*time == UUTC_NO_ENTRY)
-        return;
+	if (*time == UUTC_NO_ENTRY)
+		return;
         
 	if (*time < 0)  // negative times indicate recording time offset already applied
 		return;
@@ -754,7 +754,7 @@ inline void	apply_recording_time_offset(si8 *time)
 		*time = -(*time);
 	else
 		*time = -(*time - MEF_globals->recording_time_offset);
-        
+
 	return;
 }
 
@@ -7614,18 +7614,18 @@ void	remove_line_noise_adaptive(si4 *data, si8 n_samps, sf8 sampling_frequency, 
 
 inline void	remove_recording_time_offset(si8 *time)
 {
-    if (*time == UUTC_NO_ENTRY)
-        return;
-	
+	if (*time == UUTC_NO_ENTRY)
+		return;
+
 	if (*time >= 0)  // 0 and positive times indicate recording time offset not applied
 		return;
-	
+
 	// remove recording time offset (on valid offset entry) and make positive to indicate removal
 	if (MEF_globals->recording_time_offset == METADATA_RECORDING_TIME_OFFSET_NO_ENTRY)
 		*time = -(*time);
 	else
 		*time = (-*time) + MEF_globals->recording_time_offset;
-	
+
 	return;
 }
 


### PR DESCRIPTION
Hi Dan and Jan,

I think I've encountered a problem with writing and then reading some data.

If I write data with a (universal_header) `start_time` of 0 and an `end_time` of 10 000 000 with the section 3 field `recording_time_offset` set (e.g. to 1575439200000000), then the `start_time` does get shifted, but the `end_time` does not. So after loading (with meflib) a `start_time` of 0 will become 1575439200000000, and the `end_time` of 10 000 000 will still be 10 000 000. As soon as I set the `start_time` to be 1, then everything works as expected.

The reason this happens is because of `remove_recording_time_offset` has these lines:
```
	if (*time > 0)  // positive times indicate recording time offset not applied, 0 - unlikely any records started at 1970.
		return;
```
I think this should be `(*time >= 0)`. 
Which - I suspect - would also better correspond with what is in the `apply_recording_time_offset` function:
```
if (*time < 0)  // negative times indicate recording time offset already applied
		return;
```
Stating that only negative values have a offset applied, which means that both 0 and positive numbers do not.

In regard to the comment in the code on the unlikelihood of the 0 value (1970), this is offcourse true, but during anonymization in our lab we also reset/offset the times to count from 0. Also, a value of 1 would make equally little sense (still being in 1970), so I don't think that would be a good argument.

This pull request updates the `remove_recording_time_offset` code to `(*time >= 0)` to prevent this unexpected shift.  Curious to see what you guys think.

Best,
Max