### PR TITLE
Added function to free MEF global variables

### DIFF
--- a/meflib/meflib.c
+++ b/meflib/meflib.c
@@ -4486,10 +4486,55 @@ si4	initialize_meflib()
 	(void) SHA256_initialize_h0_table(MEF_TRUE);
 	(void) SHA256_initialize_k_table(MEF_TRUE);
 	
-	
 	return(return_value);
 }
 
+void free_meflib()
+{
+	
+	if (MEF_globals != NULL) {
+		
+		if (MEF_globals->SHA256_k_table != NULL) {
+			free(MEF_globals->SHA256_k_table);
+			MEF_globals->SHA256_k_table = NULL;
+		}
+		if (MEF_globals->SHA256_h0_table != NULL) {
+			free(MEF_globals->SHA256_h0_table);
+			MEF_globals->SHA256_h0_table = NULL;
+		}
+		if (MEF_globals->AES_rcon_table != NULL) {
+			free(MEF_globals->AES_rcon_table);
+			MEF_globals->AES_rcon_table = NULL;
+		}
+		if (MEF_globals->AES_rsbox_table != NULL) {
+			free(MEF_globals->AES_rsbox_table);
+			MEF_globals->AES_rsbox_table = NULL;
+		}
+		if (MEF_globals->AES_sbox_table != NULL) {
+			free(MEF_globals->AES_sbox_table);
+			MEF_globals->AES_sbox_table = NULL;
+		}
+		if (MEF_globals->UTF8_trailing_bytes_for_UTF8_table != NULL) {
+			free(MEF_globals->UTF8_trailing_bytes_for_UTF8_table);
+			MEF_globals->UTF8_trailing_bytes_for_UTF8_table = NULL;
+		}
+		if (MEF_globals->UTF8_offsets_from_UTF8_table != NULL) {
+			free(MEF_globals->UTF8_offsets_from_UTF8_table);
+			MEF_globals->UTF8_offsets_from_UTF8_table = NULL;
+		}
+		if (MEF_globals->CRC_table != NULL) {
+			free(MEF_globals->CRC_table);
+			MEF_globals->CRC_table = NULL;
+		}
+		if (MEF_globals->RED_normal_CDF_table != NULL) {
+			free(MEF_globals->RED_normal_CDF_table);
+			MEF_globals->RED_normal_CDF_table = NULL;
+		}
+		
+		free(MEF_globals);
+		MEF_globals = NULL;
+	}
+}
 
 si4	initialize_metadata(FILE_PROCESSING_STRUCT *fps)
 {

--- a/meflib/meflib.h
+++ b/meflib/meflib.h
@@ -562,7 +562,6 @@ void	*e_realloc(void *ptr, size_t n_bytes, const si1 *function, si4 line, ui4 be
 #define TIME_SERIES_INDEX_PROTECTED_REGION_OFFSET		40
 #define TIME_SERIES_INDEX_PROTECTED_REGION_BYTES		4
 #define TIME_SERIES_INDEX_RED_BLOCK_FLAGS_OFFSET		44		// ui1
-#define RED_BLOCK_FLAGS_BYTES					1
 #define TIME_SERIES_INDEX_RED_BLOCK_PROTECTED_REGION_OFFSET	45
 #define RED_BLOCK_PROTECTED_REGION_BYTES			3
 #define TIME_SERIES_INDEX_RED_BLOCK_DISCRETIONARY_REGION_OFFSET	48
@@ -908,8 +907,9 @@ si8			generate_recording_time_offset(si8 recording_start_time_uutc, si4 GMT_offs
 si1			*generate_segment_name(FILE_PROCESSING_STRUCT *fps, si1 *segment_name);
 ui1			*generate_UUID(ui1 *uuid);
 FILE_PROCESSING_DIRECTIVES *initialize_file_processing_directives(FILE_PROCESSING_DIRECTIVES *directives);
-void			initialize_MEF_globals(void);
+void		initialize_MEF_globals(void);
 si4			initialize_meflib(void);
+void		free_meflib(void);
 si4			initialize_metadata(FILE_PROCESSING_STRUCT *fps);
 si4			initialize_universal_header(FILE_PROCESSING_STRUCT *fps, si1 generate_level_UUID, si1 generate_file_UUID, si1 originating_file);
 si1			*local_date_time_string(si8 uutc_time, si1 *time_str);


### PR DESCRIPTION
Hi Guys,

In order to fix a memory leak in `PyMef`, I needed to add this function to `meflib` (I tested it already)

@cimbi 
If you agree with this function here, could you perhaps ensure that submodule in `PyMef` refers to this updated `MefLib`? Or let me know if you would like me to try to update the submodule in the next PyMef PR in one go
.

Thank you!

Max